### PR TITLE
fix(VTagInputField): Remove space from separator to allow multi-word …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "welltrax-ui-components",
-  "version": "1.3.0-beta.94",
+  "version": "1.3.0-beta.95",
   "description": "UI Interface Welltrax Projects",
   "author": "welltrax",
   "license": "MIT",

--- a/src/components/Form/Inputs/TagInputField.tsx
+++ b/src/components/Form/Inputs/TagInputField.tsx
@@ -41,7 +41,7 @@ export interface ITagFieldProps extends IFieldProps {
 
 @observer
 export class VTagInputField extends React.Component<ITagFieldProps> {
-  private innerSeparator = /[,\n\r\s]/;
+  private innerSeparator = /[,\n\r]/;
   @observable inputValue: any;
   @observable onPasteCapture: any;
   inputRef: any;


### PR DESCRIPTION
…tags

- Changed innerSeparator from /[,\n\r\s]/ to /[,\n\r]/
- Allows users to enter multi-word tags like 'IVAN WILSON' or 'Gross barrels'
- Space no longer triggers tag creation
- Users must press Enter to create a tag
- Preserves comma and newline separation for paste scenarios
- Fixes issue where typing a space immediately created a tag

This enables the Similar Terms field (and all other VTagInputField usages) to accept multi-word terms, which is the expected behavior for tag inputs.

Work Item: #33906
Related: Portal > Definitions > Forms & Fields > Field Settings